### PR TITLE
Switch Flux and Renovate to track main branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,7 +30,6 @@
     {
       "description": "Dependencies from comments",
       "fileMatch": [
-        "ansible/.+\\.ya?ml$",
         "cluster/.+\\.ya?ml$"
       ],
       "matchStrings": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "schedule": [
     "every weekend"
   ],
+  "minimumReleaseAge": "30 days",
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "[Renovate 🤖] Dependency Dashboard",
   "python": {

--- a/cluster/flux/flux-system/gotk-sync.yaml
+++ b/cluster/flux/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 2m30s
   ref:
-    branch: main-talos
+    branch: main
   url: http://github.com/cosminmocan/home-cluster
   ignore: |
     /*


### PR DESCRIPTION
## Summary

- **Flux** (`gotk-sync.yaml`): change tracked branch from `main-talos` → `main`
- **Renovate** (`renovate.json`): remove stale `ansible/` fileMatch from regex manager (Ansible has been removed from the repo)