### PR TITLE
Redact domain name from README and post-mortem

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A single-node Kubernetes cluster running on [Talos Linux](https://www.talos.dev/
 | [Cilium](https://cilium.io/) | CNI, kube-proxy replacement, L2 LoadBalancer IP announcements (ARP) |
 | [cert-manager](https://cert-manager.io/) | Automatic TLS certificates |
 | [ingress-nginx](https://github.com/kubernetes/ingress-nginx) | Ingress controller (`192.168.100.30`) |
-| [k8s-gateway](https://github.com/ori-edge/k8s_gateway) | Internal DNS for `*.mzone.ro` (`192.168.100.31`) |
+| [k8s-gateway](https://github.com/ori-edge/k8s_gateway) | Internal DNS for `*.REDACTED-DOMAIN` (`192.168.100.31`) |
 | [external-dns](https://github.com/kubernetes-sigs/external-dns) | Syncs DNS records to Cloudflare |
 | [cloudflare-ddns](https://github.com/favonia/cloudflare-ddns) | Keeps the public IP record up to date |
 | [Longhorn](https://longhorn.io/) | Persistent block storage |

--- a/post-mortem.md
+++ b/post-mortem.md
@@ -103,7 +103,7 @@ This bug was latent in the schematic for the entire lifetime of the cluster but 
 
 ## Stage 5 — Post-Boot: All LoadBalancer IPs Unreachable
 
-**What happened**: After the cluster came up on v1.13.0, all services backed by LoadBalancer IPs (`192.168.100.30` for nginx-ingress, `192.168.100.31` for k8s-gateway DNS) were unreachable from the LAN. DNS queries to k8s-gateway timed out. Every `*.mzone.ro` hostname was unresolvable.
+**What happened**: After the cluster came up on v1.13.0, all services backed by LoadBalancer IPs (`192.168.100.30` for nginx-ingress, `192.168.100.31` for k8s-gateway DNS) were unreachable from the LAN. DNS queries to k8s-gateway timed out. Every `*.REDACTED-DOMAIN` hostname was unresolvable.
 
 **Root cause**: Cilium's L2 announcement policy was configured to send ARP replies on interface `eth0`. The 6.18.24-talos kernel uses predictable network interface naming — on a Q35 machine with the virtio-net device on PCIe slot 18, the interface is named `ens18` instead of `eth0`. Because no interface matched the policy, Cilium sent no ARP replies for the LoadBalancer IPs. The network had no idea which MAC address owned `.30` and `.31`, so all traffic was dropped.
 


### PR DESCRIPTION
Replaces domain references in README.md and post-mortem.md with REDACTED-DOMAIN.