### PR TITLE
Fix Traefik v39 values schema

### DIFF
--- a/cluster/core/networking/traefik/app/release.yaml
+++ b/cluster/core/networking/traefik/app/release.yaml
@@ -52,8 +52,6 @@ spec:
     ports:
       web:
         port: 80
-        redirectTo:
-          port: websecure
         forwardedHeaders:
           trustedIPs:
             - "173.245.48.0/20"
@@ -78,12 +76,17 @@ spec:
             - "2405:8100::/32"
             - "2a06:98c0::/29"
             - "2c0f:f248::/32"
+        http:
+          redirections:
+            entryPoint:
+              to: websecure
+              scheme: https
+              permanent: true
       websecure:
         port: 443
-        tls:
-          enabled: true
-          options: "networking-tlsoptions@kubernetescrd"
         http:
+          tls:
+            options: "networking-tlsoptions@kubernetescrd"
           middlewares:
             - "networking-default-headers@kubernetescrd"
         forwardedHeaders:


### PR DESCRIPTION
Chart v39 changed port-level keys: `redirectTo` → `http.redirections.entryPoint`, `tls` → `http.tls`. Fixes HelmRelease install failure.