### PR TITLE
Migrate prowlarr, guacamole, radarr, jellyseerr to Traefik

### DIFF
--- a/cluster/apps/media/guacamole/release.yaml
+++ b/cluster/apps/media/guacamole/release.yaml
@@ -58,7 +58,7 @@ spec:
             port: 8080
     ingress:
       guacamole:
-        className: nginx
+        className: traefik
         hosts:
           - host: &host remote.${SECRET_DOMAIN}
             paths:

--- a/cluster/apps/media/jellyseerr/release.yaml
+++ b/cluster/apps/media/jellyseerr/release.yaml
@@ -61,7 +61,7 @@ spec:
     ingress:
       jellyseerr:
         enabled: true  # ✅ Ensures ingress is deployed
-        className: nginx
+        className: traefik
         annotations:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Jellyseerr

--- a/cluster/apps/media/prowlarr/release.yaml
+++ b/cluster/apps/media/prowlarr/release.yaml
@@ -72,7 +72,7 @@ spec:
             port: *port
     ingress:
       prowlarr:
-        className: nginx
+        className: traefik
         hosts:
           - host: &host "prowlarr.${SECRET_DOMAIN}"
             paths:

--- a/cluster/apps/media/radarr/release.yaml
+++ b/cluster/apps/media/radarr/release.yaml
@@ -70,7 +70,7 @@ spec:
             port: 7878
     ingress:
       radarr:
-        className: nginx
+        className: traefik
         hosts:
           - host: &host "radarr.${SECRET_DOMAIN}"
             paths:


### PR DESCRIPTION
These four HelmReleases used embedded ingress blocks with `className: nginx` which were missed in the initial migration. Fixes routing for those apps after ingress-nginx removal.