### PR TITLE
Fix Traefik backend routing: ClusterIP for external services, qbittorrent service name

### DIFF
--- a/cluster/apps/media/qbittorrent/ingress.yaml
+++ b/cluster/apps/media/qbittorrent/ingress.yaml
@@ -19,7 +19,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: qbittorrent
+                name: qbittorrent-qbittorrent
                 port:
                   number: 8080
   tls:

--- a/cluster/core/networking/traefik/app/release.yaml
+++ b/cluster/core/networking/traefik/app/release.yaml
@@ -46,6 +46,7 @@ spec:
       kubernetesIngress:
         enabled: true
         allowExternalNameServices: true
+        nativeLBByDefault: true
         publishedService:
           enabled: true
 


### PR DESCRIPTION
Two fixes for 503 errors after Traefik migration:

1. **`nativeLBByDefault: true`** — Traefik was resolving backends to raw endpoint IPs and connecting directly, bypassing Cilium's SNAT. External services (jellyfin, ha, music, photos, drive) live on LAN hosts that don't know how to route back to pod CIDR. Setting `nativeLBByDefault: true` makes Traefik use the ClusterIP, which Cilium intercepts and properly masquerades.

2. **qbittorrent service name** — bjw-s app-template v4 creates the service as `qbittorrent-qbittorrent` not `qbittorrent`.