### PR TITLE
Add Prowlarr and Radarr live widgets to homepage dashboard

### DIFF
--- a/cluster/apps/default/homepage/config.yaml
+++ b/cluster/apps/default/homepage/config.yaml
@@ -51,9 +51,17 @@ data:
         - Prowlarr:
             href: https://prowlarr.${SECRET_DOMAIN}
             icon: mdi-cat
+            widget:
+              type: prowlarr
+              url: http://prowlarr.media.svc.cluster.local:9696
+              key: ${PROWLARR_SECRET_KEY}
         - Radarr:
             href: https://radarr.${SECRET_DOMAIN}
             icon: filmstrip
+            widget:
+              type: radarr
+              url: http://radarr.media.svc.cluster.local:7878
+              key: ${RADARR_SECRET_KEY}
         - Jellyseerr:
             href: https://jellyseerr.${SECRET_DOMAIN}
             icon: mdi-jellyfish-outline


### PR DESCRIPTION
## Summary
- Adds live service widgets for Prowlarr (indexer stats) and Radarr (movie/queue stats) using their existing API keys from cluster secrets
- Both widgets use internal cluster DNS URLs for direct pod-to-pod communication

## Test plan
- [ ] Merge and wait for Flux to reconcile the homepage ConfigMap
- [ ] Verify Prowlarr widget shows indexer count and grab stats
- [ ] Verify Radarr widget shows movie count and queue stats