### PR TITLE
Fix homepage Host validation: set HOMEPAGE_ALLOWED_HOSTS env var

### DIFF
--- a/cluster/apps/default/homepage/release.yaml
+++ b/cluster/apps/default/homepage/release.yaml
@@ -27,6 +27,7 @@ spec:
   values:
     env:
       TZ: ${TIMEZONE}
+      HOMEPAGE_ALLOWED_HOSTS: "home.${SECRET_DOMAIN}"
     config:
       useExistingConfigMap: *app
     serviceAccount:


### PR DESCRIPTION
Adds HOMEPAGE_ALLOWED_HOSTS env var to the HelmRelease to fix the 'Host validation failed' error after Traefik migration.