### PR TITLE
Fix VPA: remove non-existent kube-prometheus-stack dependency

### DIFF
--- a/cluster/apps/monitoring/vpa/release.yaml
+++ b/cluster/apps/monitoring/vpa/release.yaml
@@ -24,19 +24,12 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
-  dependsOn:
-    - name: kube-prometheus-stack
-      namespace: monitoring
   values:
     recommender:
       enabled: true
       image:
         repository: registry.k8s.io/autoscaling/vpa-recommender
         tag: 1.6.0
-      extraArgs:
-        prometheus-address: |
-          http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
-        storage: prometheus
       resources:
         requests:
           cpu: 15m


### PR DESCRIPTION
VPA HelmRelease had a dependsOn pointing to kube-prometheus-stack which is not deployed in this cluster, causing VPA to never reconcile. Also removes the prometheus storage config since there is no Prometheus endpoint. VPA will use its default in-memory storage. Without VPA running, Goldilocks had no data to display.