### PR TITLE
Add kube-prometheus-stack, restore VPA prometheus storage backend

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/kustomization.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/kustomization.yaml
@@ -2,7 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - kube-prometheus-stack
-  - goldilocks
-  - vpa
+  - release.yaml

--- a/cluster/apps/monitoring/kube-prometheus-stack/release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/release.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: 70.x
+      sourceRef:
+        kind: HelmRepository
+        name: chart-prometheus-community
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    crds: Skip
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: Skip
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    crds:
+      enabled: false
+
+    alertmanager:
+      enabled: false
+
+    grafana:
+      enabled: true
+      defaultDashboardsTimezone: ${TIMEZONE}
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        hosts:
+          - &host grafana.${SECRET_DOMAIN}
+        tls:
+          - hosts:
+              - *host
+      persistence:
+        enabled: true
+        storageClassName: longhorn
+        size: 2Gi
+      resources:
+        requests:
+          cpu: 15m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+    prometheus:
+      prometheusSpec:
+        retention: 14d
+        retentionSize: 8GB
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: longhorn
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 10Gi
+        resources:
+          requests:
+            cpu: 50m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 15m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+    kube-state-metrics:
+      resources:
+        requests:
+          cpu: 15m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+    nodeExporter:
+      enabled: true
+
+    prometheus-node-exporter:
+      resources:
+        requests:
+          cpu: 15m
+          memory: 32Mi
+        limits:
+          memory: 64Mi

--- a/cluster/apps/monitoring/vpa/release.yaml
+++ b/cluster/apps/monitoring/vpa/release.yaml
@@ -24,12 +24,18 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: monitoring
   values:
     recommender:
       enabled: true
       image:
         repository: registry.k8s.io/autoscaling/vpa-recommender
         tag: 1.6.0
+      extraArgs:
+        prometheus-address: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+        storage: prometheus
       resources:
         requests:
           cpu: 15m


### PR DESCRIPTION
## Summary
- Deploys kube-prometheus-stack (Prometheus + Grafana + node-exporter + kube-state-metrics) into the monitoring namespace
- Grafana exposed at grafana.${SECRET_DOMAIN} via Traefik with Longhorn-backed persistence (2Gi)
- Prometheus with 14-day retention, 10Gi Longhorn storage
- AlertManager disabled (not needed for this setup)
- Restores VPA recommender to use Prometheus as storage backend — recommendations now persist across restarts and build on long-term history
- VPA depends on kube-prometheus-stack to ensure ordering

## Test plan
- [ ] kube-prometheus-stack pods come up healthy in `monitoring` namespace
- [ ] Grafana accessible at grafana domain
- [ ] VPA recommender pod starts without errors after kube-prometheus-stack is ready
- [ ] Goldilocks shows recommendations after ~10 minutes of VPA sampling