### PR TITLE
Sync Longhorn HelmRelease to 1.8.2 (already running in cluster)

### DIFF
--- a/cluster/core/longhorn-system/release.yaml
+++ b/cluster/core/longhorn-system/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.7.2
+      version: 1.8.2
       sourceRef:
         kind: HelmRepository
         name: chart-longhorn


### PR DESCRIPTION
Longhorn 1.8.2 is already running in the cluster but the HelmRelease was stuck at 1.7.2. This mismatch caused the pre-upgrade hook to fail on every reconciliation, blocking the entire dependency chain: longhorn → postgresql → authentik/pgadmin. Bumping to 1.8.2 unblocks Flux so Authentik can finally reconcile to the latest version.