### PR TITLE
Upgrade minor chart versions, Docker tags, and app-template 4.0.1 → 4.6.2

### DIFF
--- a/cluster/apps/database/pgadmin/release.yaml
+++ b/cluster/apps/database/pgadmin/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: pgadmin4
-      version: 1.28.0
+      version: 1.62.0
       sourceRef:
         kind: HelmRepository
         name: chart-runix

--- a/cluster/apps/database/redis/release.yaml
+++ b/cluster/apps/database/redis/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
-      version: 19.1.3
+      version: 19.6.4
       sourceRef:
         kind: HelmRepository
         name: chart-bitnami

--- a/cluster/apps/media/flaresolverr/release.yaml
+++ b/cluster/apps/media/flaresolverr/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: flaresolverr/flaresolverr
-              tag: v3.4.2
+              tag: v3.4.6
             resources:
               requests:
                 cpu: 50m

--- a/cluster/apps/media/guacamole/release.yaml
+++ b/cluster/apps/media/guacamole/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw

--- a/cluster/apps/media/jellyseerr/release.yaml
+++ b/cluster/apps/media/jellyseerr/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw
@@ -39,7 +39,7 @@ spec:
           app:
             image:
               repository: docker.io/fallenbagel/jellyseerr
-              tag: 2.3.0
+              tag: 2.7.3
             env:
               TZ: ${TIMEZONE}
               LOG_LEVEL: "info"

--- a/cluster/apps/media/prowlarr/release.yaml
+++ b/cluster/apps/media/prowlarr/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/onedr0p/prowlarr-develop
-              tag: 1.13.0.4217
+              tag: 1.32.2.4987
             env:
               TZ: ${TIMEZONE}
               PROWLARR__LOG_LEVEL: info

--- a/cluster/apps/media/qbittorrent/release.yaml
+++ b/cluster/apps/media/qbittorrent/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw

--- a/cluster/apps/media/radarr/release.yaml
+++ b/cluster/apps/media/radarr/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw
@@ -39,7 +39,7 @@ spec:
           app:
             image:
               repository: ghcr.io/onedr0p/radarr
-              tag: 5.2.6.8376
+              tag: 5.20.1.9773
             env:
               TZ: ${TIMEZONE}
               RADARR__LOG_LEVEL: info

--- a/cluster/apps/monitoring/goldilocks/release.yaml
+++ b/cluster/apps/monitoring/goldilocks/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: goldilocks
-      version: 10.2.0
+      version: 10.3.0
       sourceRef:
         kind: HelmRepository
         name: chart-fairwinds

--- a/cluster/apps/monitoring/kube-prometheus-stack/release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 82.x
+      version: 84.x
       sourceRef:
         kind: HelmRepository
         name: chart-prometheus-community

--- a/cluster/core/cert-manager/app/release.yaml
+++ b/cluster/core/cert-manager/app/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: v1.17.2
+      version: v1.20.1
       sourceRef:
         kind: HelmRepository
         name: chart-jetstack

--- a/cluster/core/metrics-server/release.yaml
+++ b/cluster/core/metrics-server/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: metrics-server
-      version: 3.12.1
+      version: 3.13.0
       sourceRef:
         kind: HelmRepository
         name: chart-metrics-server

--- a/cluster/core/networking/cloudflare-ddns/release.yaml
+++ b/cluster/core/networking/cloudflare-ddns/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 4.6.2
       sourceRef:
         kind: HelmRepository
         name: chart-bjw

--- a/cluster/core/networking/external-dns/release.yaml
+++ b/cluster/core/networking/external-dns/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 1.14.5
+      version: 1.20.0
       sourceRef:
         kind: HelmRepository
         name: chart-external-dns

--- a/cluster/core/reloader/release.yaml
+++ b/cluster/core/reloader/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: reloader
-      version: 2.2.9
+      version: 2.2.11
       sourceRef:
         kind: HelmRepository
         name: chart-stakater


### PR DESCRIPTION
## Chart version bumps (all within same major — no breaking changes)
- reloader: 2.2.9 → 2.2.11
- metrics-server: 3.12.1 → 3.13.0
- goldilocks: 10.2.0 → 10.3.0
- redis: 19.1.3 → 19.6.4
- pgadmin4: 1.28.0 → 1.62.0
- cert-manager: v1.17.2 → v1.20.1
- external-dns: 1.14.5 → 1.20.0
- kube-prometheus-stack: 82.x → 84.x

## Docker image tags
- prowlarr: 1.13.0.4217 → 1.32.2.4987
- radarr: 5.2.6.8376 → 5.20.1.9773
- flaresolverr: v3.4.2 → v3.4.6
- jellyseerr: 2.3.0 → 2.7.3

## app-template: 4.0.1 → 4.6.2
cloudflare-ddns, prowlarr, qbittorrent, guacamole, radarr, flaresolverr, jellyseerr