### PR TITLE
Upgrade Longhorn 1.8.2 → 1.9.2 (step 1 of 3)

### DIFF
--- a/cluster/core/longhorn-system/release.yaml
+++ b/cluster/core/longhorn-system/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.8.2
+      version: 1.9.2
       sourceRef:
         kind: HelmRepository
         name: chart-longhorn


### PR DESCRIPTION
Sequential Longhorn upgrade, step 1 of 3. Must verify all volumes healthy before proceeding to 1.10.2. Note: 1.8 → 1.9 automatically migrates CRs to v1beta2.