### PR TITLE
Upgrade Longhorn 1.9.2 → 1.10.2

### DIFF
--- a/cluster/core/longhorn-system/release.yaml
+++ b/cluster/core/longhorn-system/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.9.2
+      version: 1.10.2
       sourceRef:
         kind: HelmRepository
         name: chart-longhorn
@@ -32,6 +32,7 @@ spec:
       restoreVolumeRecurringJobs: true
       concurrentAutomaticEngineUpgradePerNodeLimit: 1
       defaultDataPath: /var/lib/longhorn/
+      defaultReplicaCount: 1
       backupTarget: "nfs://${STORAGE_NAS_IP}:/volume1/kubeNFS/cluster-backups"
       # Single-node cluster: every volume's last replica is always on this node,
       # so block-if-contains-last-replica (the default) permanently blocks all node drain.


### PR DESCRIPTION
## Summary
- Bump Longhorn chart from 1.9.2 to 1.10.2
- Add `defaultReplicaCount: 1` to defaultSettings (single-node cluster)

## Test plan
- [ ] Wait for Flux to reconcile HelmRelease
- [ ] Verify all volumes remain healthy (`kubectl get volumes -n longhorn-system`)
- [ ] Proceed to step 3 (1.10.2 → 1.11.2) once confirmed healthy