### PR TITLE
Upgrade Longhorn 1.10.2 → 1.11.2

### DIFF
--- a/cluster/core/longhorn-system/release.yaml
+++ b/cluster/core/longhorn-system/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.10.2
+      version: 1.11.2
       sourceRef:
         kind: HelmRepository
         name: chart-longhorn


### PR DESCRIPTION
## Summary
- Bump Longhorn chart from 1.10.2 to 1.11.2 (step 3 of sequential upgrade)

## Test plan
- [ ] Wait for Flux to reconcile HelmRelease
- [ ] Verify all volumes remain healthy