### PR TITLE
Upgrade cert-manager, external-dns, Flux v2.8.6, GitHub Actions

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Sync Labels
         uses: EndBug/label-sync@v2

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Labeler
-        uses: actions/labeler@v4
+        uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yaml
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/cluster/bootstrap/kustomization.yaml
+++ b/cluster/bootstrap/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - github.com/fluxcd/flux2/manifests/install?ref=v2.8.4
+  - github.com/fluxcd/flux2/manifests/install?ref=v2.8.6

--- a/cluster/core/cert-manager/app/release.yaml
+++ b/cluster/core/cert-manager/app/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: v1.20.1
+      version: v1.20.2
       sourceRef:
         kind: HelmRepository
         name: chart-jetstack

--- a/cluster/core/networking/external-dns/release.yaml
+++ b/cluster/core/networking/external-dns/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 1.20.0
+      version: 1.21.1
       sourceRef:
         kind: HelmRepository
         name: chart-external-dns

--- a/cluster/flux/flux-system/flux-install.yaml
+++ b/cluster/flux/flux-system/flux-install.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 30m
   url: https://github.com/fluxcd/flux2
   ref:
-    tag: v2.8.4
+    tag: v2.8.6
   ignore: |
     /*
     !/manifests


### PR DESCRIPTION
## Summary
- cert-manager: v1.20.1 → v1.20.2
- external-dns: 1.20.0 → 1.21.1
- Flux: v2.8.4 → v2.8.6
- actions/checkout: v3 → v6
- actions/labeler: v4 → v6