### PR TITLE
Upgrade Terraform provider minor versions

### DIFF
--- a/terraform/cloudflare/terraform.tf
+++ b/terraform/cloudflare/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "4.41.0"
+      version = "4.52.7"
     }
 
     sops = {
@@ -13,7 +13,7 @@ terraform {
 
     http = {
       source  = "hashicorp/http"
-      version = "3.2.1"
+      version = "3.5.0"
     }
   }
 }

--- a/terraform/talos/providers.tf
+++ b/terraform/talos/providers.tf
@@ -7,15 +7,15 @@ terraform {
     }
     proxmox = {
       source  = "bpg/proxmox"
-      version = "0.61.1"
+      version = "0.100.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.31.0"
+      version = "2.38.0"
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.19.1"
+      version = "1.20.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## Summary
- cloudflare: 4.41.0 → 4.52.7
- http: 3.2.1 → 3.5.0
- proxmox: 0.61.1 → 0.100.0
- kubernetes: 2.31.0 → 2.38.0
- restapi: 1.19.1 → 1.20.0