### PR TITLE
Upgrade reflector 7.1.288 → 10.0.40

### DIFF
--- a/cluster/core/reflector/release.yaml
+++ b/cluster/core/reflector/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: reflector
-      version: 7.1.288
+      version: 10.0.40
       sourceRef:
         kind: HelmRepository
         name: chart-emberstack


### PR DESCRIPTION
## Summary
- Bump reflector from 7.1.288 to 10.0.40
- Stateless controller, safe to skip intermediate majors