### PR TITLE
Fix Bitnami image pull failures (registry.bitnami.com)

### DIFF
--- a/cluster/apps/database/postgres/release.yaml
+++ b/cluster/apps/database/postgres/release.yaml
@@ -28,6 +28,8 @@ spec:
     - name: longhorn
       namespace: longhorn-system
   values:
+    global:
+      imageRegistry: registry.bitnami.com
     image:
       repository: bitnami/postgresql
       tag: 16.4.0

--- a/cluster/apps/database/redis/release.yaml
+++ b/cluster/apps/database/redis/release.yaml
@@ -25,6 +25,8 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    global:
+      imageRegistry: registry.bitnami.com
     architecture: "standalone"
     auth:
       enabled: false

--- a/cluster/apps/database/redis/release.yaml
+++ b/cluster/apps/database/redis/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
-      version: 19.6.4
+      version: 20.6.0
       sourceRef:
         kind: HelmRepository
         name: chart-bitnami


### PR DESCRIPTION
## Summary
- Add `global.imageRegistry: registry.bitnami.com` to postgresql and redis HelmReleases
- Bitnami removed older image tags from Docker Hub; their registry is now the authoritative source

## Test plan
- [ ] postgresql pod starts (pulls `registry.bitnami.com/bitnami/postgresql:16.4.0`)
- [ ] redis pod starts (pulls `registry.bitnami.com/bitnami/redis:7.2.4-debian-12-r12`)