### PR TITLE
Switch redis and postgresql to bitnamilegacy images

### DIFF
--- a/cluster/apps/database/postgres/release.yaml
+++ b/cluster/apps/database/postgres/release.yaml
@@ -28,10 +28,9 @@ spec:
     - name: longhorn
       namespace: longhorn-system
   values:
-    global:
-      imageRegistry: registry.bitnami.com
     image:
-      repository: bitnami/postgresql
+      registry: docker.io
+      repository: bitnamilegacy/postgresql
       tag: 16.4.0
     auth:
       enablePostgresUser: true

--- a/cluster/apps/database/redis/release.yaml
+++ b/cluster/apps/database/redis/release.yaml
@@ -25,8 +25,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      imageRegistry: registry.bitnami.com
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/redis
     architecture: "standalone"
     auth:
       enabled: false


### PR DESCRIPTION
## Summary
- Replace `registry.bitnami.com` (didn't work) with explicit `docker.io/bitnamilegacy/{redis,postgresql}` image references
- Bitnami Docker Hub images are no longer reliably available; bitnamilegacy is a drop-in mirror
- Long-term plan: migrate both to official Helm charts

## Test plan
- [ ] `postgresql-0` pod starts and serves connections
- [ ] `redis-master-0` pod starts