### PR TITLE
Fix Bitnami HelmRepository: switch to OCI source

### DIFF
--- a/cluster/charts/chart-bitnami.yaml
+++ b/cluster/charts/chart-bitnami.yaml
@@ -6,4 +6,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://charts.bitnami.com/bitnami/
+  type: oci
+  url: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
## Summary
- Change `chart-bitnami` HelmRepository from deprecated `https://charts.bitnami.com/bitnami/` to `oci://registry-1.docker.io/bitnamicharts`
- Bitnami moved chart distribution to OCI; the legacy HTTP repo was causing `unsupported protocol scheme "oci"` errors
- Companion to #415 (bitnamilegacy images)

## Test plan
- [ ] `flux get helmrepository chart-bitnami -n flux-system` shows Ready
- [ ] `redis-master-0` pod starts
- [ ] `postgresql-0` pod starts