### PR TITLE
Allow bitnamilegacy images: set allowInsecureImages

### DIFF
--- a/cluster/apps/database/postgres/release.yaml
+++ b/cluster/apps/database/postgres/release.yaml
@@ -28,6 +28,9 @@ spec:
     - name: longhorn
       namespace: longhorn-system
   values:
+    global:
+      security:
+        allowInsecureImages: true
     image:
       registry: docker.io
       repository: bitnamilegacy/postgresql

--- a/cluster/apps/database/redis/release.yaml
+++ b/cluster/apps/database/redis/release.yaml
@@ -25,6 +25,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    global:
+      security:
+        allowInsecureImages: true
     image:
       registry: docker.io
       repository: bitnamilegacy/redis


### PR DESCRIPTION
## Summary
- Set `global.security.allowInsecureImages: true` in redis and postgresql HelmReleases
- Bitnami chart v20+ rejects images not originating from their registry
- Required to use `docker.io/bitnamilegacy/{redis,postgresql}` images

## Test plan
- [ ] `redis-master-0` Running
- [ ] `postgresql-0` Running