### PR TITLE
Upgrade Redis 24.1.8 → 25.3.9

### DIFF
--- a/cluster/apps/database/redis/release.yaml
+++ b/cluster/apps/database/redis/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
-      version: 24.1.8
+      version: 25.3.9
       sourceRef:
         kind: HelmRepository
         name: chart-bitnami


### PR DESCRIPTION
Sequential major upgrade step 6/6. Brings redis to latest.