### PR TITLE
Upgrade PostgreSQL chart 14.3.3 → 15.5.38

### DIFF
--- a/cluster/apps/database/postgres/release.yaml
+++ b/cluster/apps/database/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: postgresql
-      version: 14.3.3
+      version: 15.5.38
       sourceRef:
         kind: HelmRepository
         name: chart-bitnami


### PR DESCRIPTION
Chart-only bump, still PG16.4.0. Chart 15.0.0 hardens security defaults (readOnlyRootFilesystem, runAsGroup). Step before the PG16→PG17 migration.