### PR TITLE
Upgrade PostgreSQL chart 15.5.38 → 16.7.27 (PG16 → PG17)

### DIFF
--- a/cluster/apps/database/postgres/release.yaml
+++ b/cluster/apps/database/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: postgresql
-      version: 15.5.38
+      version: 16.7.27
       sourceRef:
         kind: HelmRepository
         name: chart-bitnami
@@ -34,7 +34,7 @@ spec:
     image:
       registry: docker.io
       repository: bitnamilegacy/postgresql
-      tag: 16.4.0
+      tag: 17.6.0-debian-12-r4
     auth:
       enablePostgresUser: true
       postgresPassword: ${SECRET_POSTGRES_ADMIN_PASS}


### PR DESCRIPTION
Major database engine upgrade. Dump taken before migration. PVC will be recreated fresh, dump restored.