### PR TITLE
Upgrade PostgreSQL to PG17, fix ingress + dependsOn

### DIFF
--- a/cluster/apps/database/authentik/release.yaml
+++ b/cluster/apps/database/authentik/release.yaml
@@ -27,6 +27,8 @@ spec:
   dependsOn:
     - name: postgresql
       namespace: database
+    - name: redis
+      namespace: database
   values:
     authentik:
       log_level: info

--- a/cluster/apps/default/homepage/release.yaml
+++ b/cluster/apps/default/homepage/release.yaml
@@ -24,6 +24,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: traefik
+      namespace: networking
   values:
     env:
       TZ: ${TIMEZONE}

--- a/cluster/apps/media/guacamole/release.yaml
+++ b/cluster/apps/media/guacamole/release.yaml
@@ -26,6 +26,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: authentik
+      namespace: database
   values:
     controllers:
       guacamole:

--- a/cluster/apps/media/jellyseerr/release.yaml
+++ b/cluster/apps/media/jellyseerr/release.yaml
@@ -26,6 +26,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
   values:
     controllers:
       jellyseerr:

--- a/cluster/apps/media/prowlarr/release.yaml
+++ b/cluster/apps/media/prowlarr/release.yaml
@@ -26,6 +26,11 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: postgresql
+      namespace: database
+    - name: longhorn
+      namespace: longhorn-system
   values:
     controllers:
       prowlarr:

--- a/cluster/apps/media/qbittorrent/ingress.yaml
+++ b/cluster/apps/media/qbittorrent/ingress.yaml
@@ -19,7 +19,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: qbittorrent-qbittorrent
+                name: qbittorrent
                 port:
                   number: 8080
   tls:

--- a/cluster/apps/media/qbittorrent/release.yaml
+++ b/cluster/apps/media/qbittorrent/release.yaml
@@ -26,6 +26,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
   values:
     controllers:
       qbittorrent:

--- a/cluster/apps/media/radarr/release.yaml
+++ b/cluster/apps/media/radarr/release.yaml
@@ -26,6 +26,11 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: postgresql
+      namespace: database
+    - name: longhorn
+      namespace: longhorn-system
   values:
     controllers:
       radarr:

--- a/cluster/apps/monitoring/goldilocks/release.yaml
+++ b/cluster/apps/monitoring/goldilocks/release.yaml
@@ -24,6 +24,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: vpa
+      namespace: monitoring
   values:
     controller:
       resources:

--- a/cluster/apps/monitoring/kube-prometheus-stack/release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/release.yaml
@@ -27,6 +27,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
   values:
     crds:
       enabled: false

--- a/cluster/core/networking/external-dns/release.yaml
+++ b/cluster/core/networking/external-dns/release.yaml
@@ -25,6 +25,9 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  dependsOn:
+    - name: traefik
+      namespace: networking
   values:
     interval: 2m
     provider: cloudflare


### PR DESCRIPTION
## Summary
- Upgrade PostgreSQL chart 15.5.38 → 16.7.27 (PG16 → PG17 with dump/restore migration)
- Add missing Flux HelmRelease dependsOn entries across the cluster
- Fix qbittorrent ingress backend service name (was pointing to non-existent qbittorrent-qbittorrent)

## Test plan
- [x] All databases restored to PG17 and apps connected (authentik, nextcloud, *arr stack)
- [x] qbittorrent ingress patched live, accessible at qbittorrent.${SECRET_DOMAIN}
- [ ] After merge: Flux reconciles dependsOn changes without restart loops