### PR TITLE
Fix github-provider address to repository URL

### DIFF
--- a/cluster/apps/flux-system/github-alerts/provider.yaml
+++ b/cluster/apps/flux-system/github-alerts/provider.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: flux-system
 spec:
   type: github
-  address: https://api.github.com
+  address: https://github.com/cosminmocan/home-cluster
   secretRef:
     name: github-token


### PR DESCRIPTION
## Summary
Flux's GitHub commit-status notifier requires \`spec.address\` to be the repository URL so it can derive owner/repo for posting statuses. The bare API URL yielded \`invalid repository id:\` with empty value.

## Test plan
- [x] After merge, Flux notification-controller stops logging \`failed to initialize notifier\` for github-provider